### PR TITLE
Create a Guncon2 calibration with any Resolutions

### DIFF
--- a/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
+++ b/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
@@ -1714,6 +1714,84 @@ else
 	Resolution_Avoid=$(echo $Resolution_Geometry | cut -d' ' -f1)
 fi
 
+#######################################################################################
+# Select the calibration resolution for your GunCon II
+# #######################################################################################
+
+echo "####################################################################################"
+echo "##         Configure a specific resolution the calibration of your GunCon2        ##"  | tee -a /userdata/system/logs/BUILD_15KHz_Batocera.log
+echo "##                                                                                ##"
+echo "##                YES for Nvidia with Dotclok_min=25.0 (try 640x480@60Hz)         ##"
+echo "##                NO  AMD/ATI or Nvidia(Maxwell) Default is (320x240@60Hz)        ##"
+echo "##                                                                                ##"
+echo "##  EXPERIMENTAL : FOR AMD/ATI/NVIDIA YOU CAN USE OWN RESOLUTION AND SEE WHAT     ##"
+echo "##  IS BETTER AND REPORT US YOUR EXPERIENCE IN GAMES. YOU CAN TRY 640x480@60Hz    ##"
+echo "##  OR WHAT YOU WANT LIKE 768X576@50Hz. FOR THAT TYPE YES                         ##"
+echo "##                                                                                ##"
+echo "####################################################################################"
+echo ""
+declare -a Calibration_Guncon2_choice=( "YES" "NO" )
+for var in "${!Calibration_Guncon2_choice[@]}" ; do echo "			$((var+1)) : ${Calibration_Guncon2_choice[$var]}" | tee -a /userdata/system/logs/BUILD_15KHz_Batocera.log; done
+echo ""
+echo "#######################################################################"
+echo "##                         Make your choice                          ##"
+echo "#######################################################################"
+echo -n "                                  "
+read choice_Calibration_Guncon2
+while [[ ! ${choice_Calibration_Guncon2} =~ ^[1-$((var+1))]$ ]] ; do
+	echo -n "Select option 1 to $((var+1)):"
+	read choice_Calibration_Guncon2
+done
+if [  "$choice_Calibration_Guncon2" == "2" ] ; then
+	echo -e "                    your choice is :${GREEN} Bypass with 320x240@60Hz${NOCOLOR}" | tee -a /userdata/system/logs/BUILD_15KHz_Batocera.log
+	Guncon2_x=320
+	Guncon2_y=240
+	Guncon2_freq=60
+	Guncon2_res=($Guncon2_x"x"$Guncon2_y)
+	
+	Resolution_Avoid=$(echo $Resolution_Geometry | cut -d' ' -f1)
+else
+	echo "###############################################################################"
+	echo "##      Select your custom horizontal resolution for Guncon2 calibration     ##"
+	echo "###############################################################################"
+	echo -n "                                  "
+	read  Guncon2_x
+	while [[ ! $Guncon2_x =~ ^[0-9]+$ || "$Guncon2_x" -lt 0 ]] ; do
+		echo -n "Enter valid number greater than 0 for Guncon2_x"
+		read Guncon2_x
+	done
+	echo
+ 	echo -e "                    CUSTOM Guncon2_x Horizontal resolution  = ${GREEN}${Guncon2_x}${NOCOLOR}" | tee -a /userdata/system/logs/BUILD_15KHz_Batocera.log
+	echo "###############################################################################"
+	echo "##      Select your custom vertical resolution for Guncon2 calibration       ##"
+	echo "###############################################################################"
+
+	echo -n "                                  "
+	read  Guncon2_y
+	while [[ ! $Guncon2_y =~ ^[0-9]+$ || "$Guncon2_y" -lt 0 ]] ; do
+		echo -n "Enter valid number greater than 0 for Guncon2_y"
+		read Guncon2_y
+	done
+	echo
+ 	echo -e "                    CUSTOM Guncon2_y Horizontal resolution  = ${GREEN}${Guncon2_y}${NOCOLOR}" | tee -a /userdata/system/logs/BUILD_15KHz_Batocera.log
+
+	echo "###############################################################################"
+	echo "##      Select your custom frequency resolution for Guncon2 calibration      ##"
+	echo "###############################################################################"
+
+	echo -n "                                  "
+	read  Guncon2_freq
+	while [[ ! $Guncon2_freq =~ ^[0-9]+$ || "Guncon2_freq" -lt 0 ]] ; do
+		echo -n "Enter valid number greater than 0 for calibration_frequency "
+		read Guncon2_freq
+	done
+ 	echo -e "                    CUSTOM frequency resolution  = ${GREEN}${calibration_frequency}${NOCOLOR}" | tee -a /userdata/system/logs/BUILD_15KHz_Batocera.log
+
+	Guncon2_res=($Guncon2_x"x"$Guncon2_y)
+
+fi
+
+
 echo ""
 echo "#######################################################################"
 echo "##                                                                   ##"
@@ -1781,7 +1859,35 @@ if [ "$Version_of_batocera" == "v36" ]||[ "$Version_of_batocera" == "v37" ]||[ "
 	chmod 644 /usr/share/batocera/shaders/misc/shaders/image-adjustment_lgun.slang
 fi
 
+if [ "$Version_of_batocera" == "v36" ]||[ "$Version_of_batocera" == "v37" ]||[ "$Version_of_batocera" == "v38" ]; then
 
+	if [ ! -f "/etc/udev/rules.d/99-guncon.rules.bak" ];then                                                           
+		cp /etc/udev/rules.d/99-guncon.rules /etc/udev/rules.d/99-guncon.rules.bak                       
+	fi
+ 
+	cp /userdata/system/BUILD_15KHz/GunCon2/99-guncon.rules-generic /etc/udev/rules.d/99-guncon.rules
+
+        if [ ! -f "/usr/bin/guncon2_calibrate.sh.bak" ];then                                                           
+		cp /usr/bin/guncon2_calibrate.sh /usr/bin/guncon2_calibrate.sh.bak                      
+	fi
+
+	sed -e "s/\[guncon2_x\]/$Guncon2_x/g" -e "s/\[guncon2_y\]/$Guncon2_y/g" -e "s/\[guncon2_f\]/$Guncon2_freq/g" -e "s/\[guncon2_res\]/$Guncon2_res/g" \
+		/userdata/system/BUILD_15KHz/GunCon2/guncon2_calibrate.sh-generic  > /usr/bin/guncon2_calibrate.sh
+        chmod 755 /usr/bin/guncon2_calibrate.sh
+
+
+	if [ ! -f "/usr/bin/calibrate.py.bak" ];then                                                           
+		cp /usr/bin/calibrate.py /usr/bin/calibrate.py.bak                      
+	fi
+	if [ "$ES_rotation" == "NORMAL" ] || [ "$ES_rotation" == "INVERTED" ]; then	
+		sed -e "s/\[guncon2_x\]/$Guncon2_x/g" -e "s/\[guncon2_y\]/$Guncon2_y/g"  -e "s/\[guncon2_res\]/$Guncon2_res/g" \
+		       	/userdata/system/BUILD_15KHz/GunCon2/calibrate.py-generic   > /usr/bin/calibrate.py
+	else
+		sed -e "s/\[guncon2_y\]/$Guncon2_x/g" -e "s/\[guncon2_x\]/$Guncon2_y/g"  -e "s/\[guncon2_res\]/$Guncon2_res/g" \
+		       	/userdata/system/BUILD_15KHz/GunCon2/calibrate.py-generic   > /usr/bin/calibrate.py
+	fi
+	chmod 755 /usr/bin/calibrate.py
+fi
 
 #######################################################################################
 ## Save in compilation in batocera image


### PR DESCRIPTION
The explication is in following text:

Configure a specific resolution the calibration of your GunCon2       

       1)  YES: for Nvidia with Dotclok_min=25.0 (try 640x480@60Hz)        
        2)  NO:  for AMD/ATI or Nvidia(Maxwell) Default is (320x240@60Hz)   
    
 EXPERIMENTAL : FOR AMD/ATI/NVIDIA YOU CAN USE OWN RESOLUTION AND SEE WHAT     
 IS BETTER AND REPORT US YOUR EXPERIENCE IN GAMES. YOU CAN TRY 640x480@60Hz    
 OR WHAT YOU WANT LIKE 768X576@50Hz. FOR THAT TYPE YES            
